### PR TITLE
Add Rails 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ rvm:
 - 1.9.3
 - 2.2.10
 - 2.3.8
-- 2.4.5
-- 2.5.3
-- jruby-9.2.5.0
+- 2.4.7
+- 2.5.6
+- 2.6.4
+- jruby-9.2.8.0
 before_install: gem install bundler -v 1.17.3
 gemfile:
 - gemfiles/rails-3.2.gemfile
@@ -30,25 +31,29 @@ matrix:
   exclude:
     - rvm: 1.9.3
     - gemfile: gemfiles/rails-edge.gemfile
-    - rvm: 2.4.5
+    - rvm: 2.4.7
       gemfile: gemfiles/rails-4.0.gemfile
-    - rvm: 2.4.5
+    - rvm: 2.4.7
       gemfile: gemfiles/rails-4.1.gemfile
-    - rvm: 2.5.3
+    - rvm: 2.5.6
       gemfile: gemfiles/rails-3.2.gemfile
-    - rvm: 2.5.3
+    - rvm: 2.5.6
       gemfile: gemfiles/rails-4.0.gemfile
-    - rvm: 2.5.3
+    - rvm: 2.5.6
+      gemfile: gemfiles/rails-4.1.gemfile
+    - rvm: 2.6.4
+      gemfile: gemfiles/rails-4.0.gemfile
+    - rvm: 2.6.4
       gemfile: gemfiles/rails-4.1.gemfile
   include:
-    - rvm: 2.5.3
+    - rvm: 2.5.6
       gemfile: gemfiles/rails-edge.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/rails-3.2.gemfile
   allow_failures:
   - rvm: 1.9.3 # bundler wont install the gems
   - gemfile: gemfiles/rails-edge.gemfile
-  - rvm: jruby-9.2.5.0
+  - rvm: jruby-9.2.8.0
 notifications:
   email: false
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ gemfile:
 - gemfiles/rails-5.0.gemfile
 - gemfiles/rails-5.1.gemfile
 - gemfiles/rails-5.2.gemfile
+- gemfiles/rails-6.0.gemfile
 - gemfiles/rails-edge.gemfile
 env:
   global: RAILS_ENV=test
@@ -31,10 +32,16 @@ matrix:
   exclude:
     - rvm: 1.9.3
     - gemfile: gemfiles/rails-edge.gemfile
+    - rvm: 2.2.10
+      gemfile: gemfiles/rails-6.0.gemfile
+    - rvm: 2.3.8
+      gemfile: gemfiles/rails-6.0.gemfile
     - rvm: 2.4.7
       gemfile: gemfiles/rails-4.0.gemfile
     - rvm: 2.4.7
       gemfile: gemfiles/rails-4.1.gemfile
+    - rvm: 2.4.7
+      gemfile: gemfiles/rails-6.0.gemfile
     - rvm: 2.5.6
       gemfile: gemfiles/rails-3.2.gemfile
     - rvm: 2.5.6

--- a/gemfiles/rails-3.0.gemfile
+++ b/gemfiles/rails-3.0.gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 3.0.0'
-# TODO: REMOVE ME
-gem 'timber', git: 'https://github.com/timberio/timber-ruby.git', branch: '3.0-cleanup'
-gem 'timber-rack', git: 'https://github.com/timberio/timber-ruby-rack.git', branch: 'master'
+
+gem 'timber',
+gem 'timber-rack'
 
 gemspec :path => '../'

--- a/gemfiles/rails-3.1.gemfile
+++ b/gemfiles/rails-3.1.gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 3.1.0'
-# TODO: REMOVE ME
-gem 'timber', git: 'https://github.com/timberio/timber-ruby.git', branch: '3.0-cleanup'
-gem 'timber-rack', git: 'https://github.com/timberio/timber-ruby-rack.git', branch: 'master'
+
+gem 'timber'
+gem 'timber-rack'
 
 gemspec :path => '../'

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 3.2.0'
-# TODO: REMOVE ME
-gem 'timber', git: 'https://github.com/timberio/timber-ruby.git', branch: '3.0-cleanup'
-gem 'timber-rack', git: 'https://github.com/timberio/timber-ruby-rack.git', branch: 'master'
+
+gem 'timber'
+gem 'timber-rack'
 
 gemspec :path => '../'

--- a/gemfiles/rails-4.0.gemfile
+++ b/gemfiles/rails-4.0.gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 4.0.0'
-# TODO: REMOVE ME
-gem 'timber', git: 'https://github.com/timberio/timber-ruby.git', branch: '3.0-cleanup'
-gem 'timber-rack', git: 'https://github.com/timberio/timber-ruby-rack.git', branch: 'master'
+
+gem 'timber'
+gem 'timber-rack'
 
 if RUBY_PLATFORM == "java"
   gem 'mime-types', '2.6.2'

--- a/gemfiles/rails-4.1.gemfile
+++ b/gemfiles/rails-4.1.gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 4.1.0'
-# TODO: REMOVE ME
-gem 'timber', git: 'https://github.com/timberio/timber-ruby.git', branch: '3.0-cleanup'
-gem 'timber-rack', git: 'https://github.com/timberio/timber-ruby-rack.git', branch: 'master'
+
+gem 'timber'
+gem 'timber-rack'
 
 if RUBY_PLATFORM == "java"
   gem 'mime-types', '2.6.2'

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
-# TODO: REMOVE ME
-gem 'timber', git: 'https://github.com/timberio/timber-ruby.git', branch: '3.0-cleanup'
-gem 'timber-rack', git: 'https://github.com/timberio/timber-ruby-rack.git', branch: 'master'
+
+gem 'timber'
+gem 'timber-rack'
 
 if RUBY_PLATFORM == "java"
   gem 'mime-types', '2.6.2'

--- a/gemfiles/rails-5.0.gemfile
+++ b/gemfiles/rails-5.0.gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0.0'
-# TODO: REMOVE ME
-gem 'timber', git: 'https://github.com/timberio/timber-ruby.git', branch: '3.0-cleanup'
-gem 'timber-rack', git: 'https://github.com/timberio/timber-ruby-rack.git', branch: 'master'
+
+gem 'timber'
+gem 'timber-rack'
 
 if RUBY_PLATFORM == "java"
   gem 'mime-types', '2.6.2'

--- a/gemfiles/rails-5.1.gemfile
+++ b/gemfiles/rails-5.1.gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.1.0'
-# TODO: REMOVE ME
-gem 'timber', git: 'https://github.com/timberio/timber-ruby.git', branch: '3.0-cleanup'
-gem 'timber-rack', git: 'https://github.com/timberio/timber-ruby-rack.git', branch: 'master'
+
+gem 'timber'
+gem 'timber-rack'
 
 if RUBY_PLATFORM == "java"
   gem 'mime-types', '2.6.2'

--- a/gemfiles/rails-5.2.gemfile
+++ b/gemfiles/rails-5.2.gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.2.0'
-# TODO: REMOVE ME
-gem 'timber', git: 'https://github.com/timberio/timber-ruby.git', branch: '3.0-cleanup'
-gem 'timber-rack', git: 'https://github.com/timberio/timber-ruby-rack.git', branch: 'master'
+
+gem 'timber'
+gem 'timber-rack'
 
 if RUBY_PLATFORM == "java"
   gem 'mime-types', '2.6.2'

--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 6.0.0'
+
+gem 'timber'
+gem 'timber-rack'
+
+if RUBY_PLATFORM == "java"
+  gem 'mime-types', '2.6.2'
+end
+
+gemspec :path => '../'

--- a/gemfiles/rails-edge.gemfile
+++ b/gemfiles/rails-edge.gemfile
@@ -4,8 +4,7 @@ gem 'rack', git: 'https://github.com/rack/rack', branch: 'master'
 gem 'arel', git: 'https://github.com/rails/arel', branch: 'master'
 gem 'rails', git: 'https://github.com/rails/rails', branch: 'master'
 
-# TODO: REMOVE ME
-gem 'timber', git: 'https://github.com/timberio/timber-ruby.git', branch: '3.0-cleanup'
-gem 'timber-rack', git: 'https://github.com/timberio/timber-ruby-rack.git', branch: 'master'
+gem 'timber'
+gem 'timber-rack'
 
 gemspec :path => '../'

--- a/lib/timber-rails/logger.rb
+++ b/lib/timber-rails/logger.rb
@@ -9,7 +9,12 @@ module Timber
   #   logger.info "Payment rejected", payment_rejected: {customer_id: customer_id, amount: 100}
   class Logger < ::Logger
     include ::ActiveSupport::LoggerThreadSafeLevel if defined?(::ActiveSupport::LoggerThreadSafeLevel)
-    include ::LoggerSilence if defined?(::LoggerSilence)
+
+    if defined?(::ActiveSupport::LoggerSilence)
+      include ::ActiveSupport::LoggerSilence
+    elsif defined?(::LoggerSilence)
+      include ::LoggerSilence
+    end
   end
 end
 

--- a/timber-rails.gemspec
+++ b/timber-rails.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rails", ">= 3.0.0", "< 6.0.0"
+  spec.add_runtime_dependency "rails", ">= 3.0.0"
   spec.add_runtime_dependency "timber", "~> 3.0"
   spec.add_runtime_dependency "timber-rack", "~> 1.0"
 
@@ -47,10 +47,22 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("rspec-its", ">= 0")
   spec.add_development_dependency("timecop", ">= 0")
 
+  rails_version = 0
+  if ENV.key?('RAILS_VERSION')
+    rails_version = ENV['RAILS_VERSION'].to_f
+  elsif ENV.key?('BUNDLE_GEMFILE')
+    matches = File.basename(ENV['BUNDLE_GEMFILE'], '.gemfile').match(/-([0-9.]+)\z/)
+    rails_version = matches[1].to_f if matches
+  end
+
   if RUBY_PLATFORM == "java"
     spec.add_development_dependency('activerecord-jdbcsqlite3-adapter', '>= 0')
   else
-    spec.add_development_dependency('sqlite3', '1.3.13')
+    if rails_version >= 6
+      spec.add_development_dependency('sqlite3', '~> 1.4.0')
+    else
+      spec.add_development_dependency('sqlite3', '1.3.13')
+    end
   end
 
   if RUBY_VERSION


### PR DESCRIPTION
The gem works fine in Rails 6 already, so this PR is relaxing the Rails version requirements specified in the Gemspec and also addresses a deprecation warning.

Additionally, this PR gets the Travis CI builds working again.