### PR TITLE
Bump version

### DIFF
--- a/lib/timber-rails/version.rb
+++ b/lib/timber-rails/version.rb
@@ -1,7 +1,7 @@
 module Timber
   module Integrations
     module Rails
-      VERSION = "1.0.1"
+      VERSION = "1.0.2"
     end
   end
 end


### PR DESCRIPTION
Looks like [a new release needs to be cut for Rubygems since the PR relaxing the Rails requirements](https://github.com/timberio/timber-ruby-rails/pull/3#issuecomment-542731146). Happy to help, if I can. Thanks!

Closes #4 

