### PR TITLE
Accept any arguments for `log_rendering_start`

### DIFF
--- a/lib/timber-rails/action_view/log_subscriber/timber_log_subscriber.rb
+++ b/lib/timber-rails/action_view/log_subscriber/timber_log_subscriber.rb
@@ -67,7 +67,7 @@ module Timber
           end
 
           private
-            def log_rendering_start(payload)
+            def log_rendering_start(*args)
               # Consolidates 2 template rendering events into 1. We don't need 2 events for
               # rendering a template. If you disagree, please feel free to open a PR and we
               # can make this an option.


### PR DESCRIPTION
Hey folks,

We're experimenting with running our app on edge, and the method signature for `log_rendering_start` has seemingly changed.  https://github.com/rails/rails/pull/38999

I realize this change is a bit ahead of time given Rails 6.1.0 is still in alpha, but since this seems to be a no-op anyway, it seems ok to accept any arguments? What do you think?